### PR TITLE
feat: send system timezone when configuration change

### DIFF
--- a/app/src/main/java/com/mrboombastic/buwudzik/ui/screens/DeviceSettingsScreen.kt
+++ b/app/src/main/java/com/mrboombastic/buwudzik/ui/screens/DeviceSettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.mrboombastic.buwudzik.ui.screens
 
+import android.icu.util.TimeZone
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -139,10 +140,6 @@ fun DeviceSettingsScreen(navController: NavController, viewModel: MainViewModel)
                 var nightEndHour by remember { mutableIntStateOf(currentSettings.nightEndHour) }
                 var nightEndMinute by remember { mutableIntStateOf(currentSettings.nightEndMinute) }
 
-                // Metadata preserved from device
-                val timezoneOffset = currentSettings.timezoneOffset
-                val timezoneSign = currentSettings.timezoneSign
-
                 // Define save function using current state
                 @Suppress("AssignedValueIsNeverRead")
                 val saveSettings = {
@@ -151,8 +148,7 @@ fun DeviceSettingsScreen(navController: NavController, viewModel: MainViewModel)
                         timeFormat = timeFormat,
                         language = language,
                         volume = volume.toInt(),
-                        timezoneOffset = timezoneOffset,
-                        timezoneSign = timezoneSign,
+                        timeZone = TimeZone.getDefault(),
                         nightModeBrightness = nightModeBrightness.toInt(),
                         backlightDuration = backlightDuration.toInt(),
                         screenBrightness = screenBrightness.toInt(),


### PR DESCRIPTION
Thank you for your AMAZING app!

your app is not changing the time zone, and the default settings are +5h (in my model fw version 1.0.1_0132)

with this PR I use the mobile's timezone when creating the new settings.

I decided to avoid to use the raw bytes in the settings but encode/decode the timezone inside the QPController.




